### PR TITLE
0.2.0 Request Signing

### DIFF
--- a/cognito.gemspec
+++ b/cognito.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 11.2'
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'rubocop', '~> 0.41'
+  spec.add_development_dependency 'timecop', '~> 0.8'
 
   spec.add_dependency 'abstract_type', '~> 0.0.7'
   spec.add_dependency 'adamantium', '~> 0.2.0'

--- a/lib/cognito.rb
+++ b/lib/cognito.rb
@@ -2,7 +2,11 @@
 
 require 'bundler/setup'
 
+require 'base64'
+require 'digest'
 require 'json'
+require 'openssl'
+require 'time'
 
 require 'abstract_type'
 require 'adamantium'
@@ -21,6 +25,7 @@ require 'cognito/resource/identity_assessment'
 require 'cognito/constants'
 require 'cognito/error'
 require 'cognito/version'
+require 'cognito/notary'
 
 require 'cognito/responder'
 require 'cognito/client'

--- a/lib/cognito/notary.rb
+++ b/lib/cognito/notary.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Cognito
+  # Signs Cognito requests.
+  class Notary
+    CONTENT_TYPE = ACCEPT_TYPE = 'application/vnd.api+json'
+    COGNITO_VERSION = '2016-09-01'
+
+    attr_reader :api_key, :api_secret, :body, :target
+
+    def initialize(api_key:, api_secret:, body:, target:)
+      @api_key = api_key
+      @api_secret = api_secret
+      @body = body
+      @target = target
+    end
+
+    def headers
+      @headers ||= {
+        'Date' => date,
+        'Digest' => digest,
+        'Authorization' => authorization,
+        'Content-Type' => CONTENT_TYPE,
+        'Accept' => ACCEPT_TYPE,
+        'Cognito-Version' => COGNITO_VERSION
+      }
+    end
+
+    def authorization
+      @authorization ||= [
+        'Signature keyId="' + api_key + '"',
+        'algorithm="hmac-sha256"',
+        'headers="date digest (request-target)"',
+        'signature="' + signature + '"'
+      ].join(',')
+    end
+
+    def digest
+      @digest ||=
+        "SHA-256=#{Base64.strict_encode64(Digest::SHA256.digest(body))}"
+    end
+
+    def date
+      @date ||= Time.now.httpdate
+    end
+
+    def signature
+      @signature ||= Base64.strict_encode64(
+        OpenSSL::HMAC.digest(
+          OpenSSL::Digest::SHA256.new, api_secret, signing_string
+        )
+      )
+    end
+
+    def signing_string
+      @signing_string ||= [
+        "date: #{date}",
+        "digest: #{digest}",
+        "(request-target): #{target}"
+      ].join("\n")
+    end
+  end
+end

--- a/spec/notary_spec.rb
+++ b/spec/notary_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Cognito::Notary do
+  describe '#initialize' do
+    let(:api_key) { 'foo' }
+    let(:api_secret) { 'bar' }
+    let(:target) { 'post /profiles' }
+    let(:body) { JSON.generate(foo: 'bar') }
+
+    it 'requires api_key' do
+      expect {
+        described_class.new(api_secret: api_secret, target: target, body: body)
+      }.to raise_exception(ArgumentError, 'missing keyword: api_key')
+    end
+
+    it 'requires api_secret' do
+      expect {
+        described_class.new(api_key: api_key, target: target, body: body)
+      }.to raise_exception(ArgumentError, 'missing keyword: api_secret')
+    end
+
+    it 'requires body' do
+      expect {
+        described_class.new(
+          api_key: api_key,
+          api_secret: api_secret,
+          target: target
+        )
+      }.to raise_exception(ArgumentError, 'missing keyword: body')
+    end
+
+    it 'requires target' do
+      expect {
+        described_class.new(
+          api_key: api_key,
+          api_secret: api_secret,
+          body: body
+        )
+      }.to raise_exception(ArgumentError, 'missing keyword: target')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'cognito'
+require 'timecop'
 
 # Require helper files.
 Dir[File.join(File.dirname(__FILE__), '/support/**/*.rb')].each do |file|


### PR DESCRIPTION
Implement new request signing mechanism for Cognito as of Sept 1, 2016. New auth is encapsulated in the `Cognito::Witness` class.

Reference: https://cognitohq.com/docs/authenticating
Username: letmein
