### PR TITLE
Upgrade to 0.3.0

### DIFF
--- a/lib/cognito/client.rb
+++ b/lib/cognito/client.rb
@@ -10,9 +10,19 @@ module Cognito
     # Default URI, can be override with Client#base_uri
     base_uri URI
 
-    def initialize(api_key:, api_secret:)
-      @api_key = api_key
-      @api_secret = api_secret
+    # Don't follow redirects.
+    no_follow true
+    follow_redirects false
+
+    def initialize(options = {})
+      @errors = []
+      @api_key = options.fetch(:api_key) { @errors << :api_key }
+      @api_secret = options.fetch(:api_secret) { @errors << :api_secret }
+      self.base_uri = options.fetch(:base_uri) { URI }
+
+      if @errors.any?
+        raise ArgumentError, "missing keyword: #{@errors.join(',')}"
+      end
     end
 
     def base_uri=(uri)
@@ -30,6 +40,10 @@ module Cognito
 
     def search_status!(search_job_id)
       get("/identity_searches/jobs/#{search_job_id}")
+    end
+
+    def retrieve_search(search_id)
+      get("/identity_searches/#{search_id}")
     end
 
     protected

--- a/lib/cognito/version.rb
+++ b/lib/cognito/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Cognito
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -60,6 +60,9 @@ RSpec.describe Cognito::Client do
   end
 
   describe '#initialize' do
+    let(:uri) { 'api.cognitohq.com' }
+    let(:normalized_uri) { HTTParty.normalize_base_uri(uri) }
+
     it 'requires an :api_key' do
       expect {
         described_class.new(api_secret: api_secret)
@@ -71,6 +74,16 @@ RSpec.describe Cognito::Client do
         described_class.new(api_key: api_key)
       }.to raise_exception(ArgumentError, 'missing keyword: api_secret')
     end
+
+    it 'accepts :base_uri as optional argument' do
+      client = described_class.new(
+        api_key: api_key,
+        api_secret: api_secret,
+        base_uri: uri
+      )
+
+      expect(client.class.base_uri).to eq(normalized_uri)
+    end
   end
 
   describe '#base_uri=' do
@@ -81,7 +94,7 @@ RSpec.describe Cognito::Client do
       client.base_uri = uri
 
       # Unable to test this behavior without violating encapsulation.
-      expect(client.class.default_options[:base_uri]).to eq(normalized_uri)
+      expect(client.class.base_uri).to eq(normalized_uri)
     end
   end
 


### PR DESCRIPTION
- Adds option to configure `base_uri` at initialization
- Do not follow redirects automagically
- Bump version
