### PR TITLE
Change gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently in the "make it work" phase of development.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'cognito', git: 'https://github.com/opendoor-labs/cognito.git'
+gem 'cognito-client', require: 'cognito'
 ```
 
 And then execute:

--- a/cognito.gemspec
+++ b/cognito.gemspec
@@ -5,12 +5,12 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cognito/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'cognito'
+  spec.name          = 'cognito-client'
   spec.version       = Cognito::VERSION
   spec.authors       = ['Connor Jacobsen']
   spec.email         = ['connor@opendoor.com']
 
-  spec.summary       = 'Ruby client for the BlockScore Cognito API'
+  spec.summary       = 'Unofficial Ruby client for the BlockScore Cognito API'
   spec.homepage      = 'https://github.com/opendoor-labs/cognito'
   spec.license       = 'MIT'
 

--- a/lib/cognito/version.rb
+++ b/lib/cognito/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Cognito
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
@alainmeier Going to publish to RubyGems with gem name `cognito-client` as version `0.4.1` before merging #24 as `0.5.0`.

After #24 lands we can probably remove `lib/cognito.rb` and just leave `lib/cognito/client.rb` and bundler will handle the `require` bit for us.