### PR TITLE
Remove client request.rb flog exclusion

### DIFF
--- a/config/flog.yml
+++ b/config/flog.yml
@@ -1,5 +1,4 @@
 ---
 threshold: 17.8
 lib_dirs:
-  - -lib/cog/client/request.rb  # Uses squiggly heredoc
   - lib


### PR DESCRIPTION
I removed the squiggly heredoc that previously broke flog parsing, so I have removed this file from the list of exclusions.