### PR TITLE
Add populated json property on Response object

### DIFF
--- a/lib/cognito/client/response.rb
+++ b/lib/cognito/client/response.rb
@@ -3,7 +3,7 @@
 class Cognito
   class Client
     class Response
-      include Anima.new(:status, :headers, :data, :connection)
+      include Anima.new(:status, :headers, :data, :json, :connection)
 
       def self.build(response, connection)
         new(Builder.call(response).merge(connection: connection))

--- a/lib/cognito/client/response/builder.rb
+++ b/lib/cognito/client/response/builder.rb
@@ -10,7 +10,8 @@ class Cognito
           {
             status:  build_status,
             headers: response.headers.to_hash,
-            data:    build_data
+            data:    build_data,
+            json:    response.body.to_s
           }
         end
 

--- a/spec/unit/cognito/client/response_spec.rb
+++ b/spec/unit/cognito/client/response_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Cognito::Client::Response do
       headers:    headers,
       data:       nil,
       connection: connection,
-      json: ''
+      json:       ''
     )
   end
 

--- a/spec/unit/cognito/client/response_spec.rb
+++ b/spec/unit/cognito/client/response_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Cognito::Client::Response do
       status:     described_class::Status.new(code: 201, reason: 'Created'),
       headers:    headers,
       data:       nil,
-      connection: connection
+      connection: connection,
+      json: ''
     )
   end
 
@@ -58,7 +59,8 @@ RSpec.describe Cognito::Client::Response do
 
       is_expected.to eql(
         created_response.with(
-          data: Cognito::Client::Resource::Profile.build(document.data, document)
+          data: Cognito::Client::Resource::Profile.build(document.data, document),
+          json: body
         )
       )
     end


### PR DESCRIPTION
This adds a `json` property on the `Response` object so its easy to get the raw JSON string say for storing in a database (e.g. Postgres where you can query it).

This also works with the library since you could just pipe the JSON back into it so its easier to work with the JSON at a later point if needed. For example, this would be done by creating a stub `HTTP::Response` object:

```ruby
response = HTTP::Response.new(body: json, status: 200, version: '1.1')
profile = Cognito::Client::Response::Profile.build(json, nil)
```