### PR TITLE
Fix missing `Content-Location` bug on second use of `Command::RetrieveIdentitySearchJob`

### DIFF
--- a/lib/cognito/client/commands/create_identity_search.rb
+++ b/lib/cognito/client/commands/create_identity_search.rb
@@ -25,7 +25,7 @@ class Cognito
         def present_response
           case response.code
           when 202
-            Response::IdentitySearchJob.build(response, connection)
+            Response::IdentitySearchJob.build(response, connection, response['Content-Location'])
           when 201
             Response::IdentitySearch.build(response, connection)
           end

--- a/lib/cognito/client/commands/retrieve_identity_search_job.rb
+++ b/lib/cognito/client/commands/retrieve_identity_search_job.rb
@@ -24,7 +24,7 @@ class Cognito
         end
 
         def processing_response
-          Response::IdentitySearchJob.build(response, connection)
+          Response::IdentitySearchJob.build(response, connection, endpoint)
         end
 
         def success?

--- a/lib/cognito/client/response/identity_search_job.rb
+++ b/lib/cognito/client/response/identity_search_job.rb
@@ -4,16 +4,25 @@ class Cognito
   class Client
     class Response
       class IdentitySearchJob < self
+        def self.build(response, connection, endpoint)
+          identity_search_job =
+            new(Builder.call(response).merge(connection: connection))
+          identity_search_job.endpoint = endpoint
+          identity_search_job
+        end
+
         def get
           Command::RetrieveIdentitySearchJob.call(
             connection,
-            headers.fetch('Content-Location')
+            endpoint
           )
         end
 
         def processing?
           true
         end
+
+        attr_accessor :endpoint
       end # IdentitySearchJob
     end # Response
   end # Client

--- a/spec/unit/cognito/client/command/create_identity_search_spec.rb
+++ b/spec/unit/cognito/client/command/create_identity_search_spec.rb
@@ -158,13 +158,15 @@ RSpec.describe Cognito::Client::Command::CreateIdentitySearch do
 
   context 'when request is ACCEPTED 202' do
     let(:headers) do
-      { 'Content-Location' => '/identity_searches/jobs/o3irufoai3o' }
+      { 'Content-Location' => location }
     end
+    let(:location) { '/identity_searches/jobs/o3irufoai3o' }
 
     it 'returns a processing identity response' do
       is_expected.to eql(
-        Cognito::Client::Response::IdentitySearchJob.build(http_response, connection)
+        Cognito::Client::Response::IdentitySearchJob.build(http_response, connection, location)
       )
+      expect(response.endpoint).to eql location
     end
   end
 

--- a/spec/unit/cognito/client/command/retrieve_identity_search_job_spec.rb
+++ b/spec/unit/cognito/client/command/retrieve_identity_search_job_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Cognito::Client::Command::RetrieveIdentitySearchJob do
 
     it 'receives run with the correct params' do
       is_expected.to eql(
-        Cognito::Client::Response::IdentitySearchJob.build(http_response, connection)
+        Cognito::Client::Response::IdentitySearchJob.build(http_response, connection, location)
       )
 
       expect(connection).to have_received(:run).with(request)
@@ -67,21 +67,22 @@ RSpec.describe Cognito::Client::Command::RetrieveIdentitySearchJob do
 
     it 'returns a processing identity_search response' do
       is_expected.to eql(
-        Cognito::Client::Response::IdentitySearchJob.build(http_response, connection)
+        Cognito::Client::Response::IdentitySearchJob.build(http_response, connection, location)
       )
 
       expect(response.data.status).to eql('processing')
+      expect(response.endpoint).to eql location
     end
 
     context 'BUG: builds an IdentitySearchJob which expects a `Content-Location` header' do
-      it 'raises error for missing `Content-Location` header' do
+      it 'does not raise error for missing `Content-Location` header' do
         is_expected.to eql(
           Cognito::Client::Response::IdentitySearchJob.build(http_response, connection, location)
         )
         allow(Cognito::Client::Command::RetrieveIdentitySearchJob).to receive(:call)
         expect do
           response.get
-        end.to raise_error KeyError, /Content-Location/
+        end.to_not raise_error KeyError, /Content-Location/
       end
     end
   end

--- a/spec/unit/cognito/client/command/retrieve_identity_search_job_spec.rb
+++ b/spec/unit/cognito/client/command/retrieve_identity_search_job_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe Cognito::Client::Command::RetrieveIdentitySearchJob do
 
       expect(response.data.status).to eql('processing')
     end
+
+    context 'BUG: builds an IdentitySearchJob which expects a `Content-Location` header' do
+      it 'raises error for missing `Content-Location` header' do
+        is_expected.to eql(
+          Cognito::Client::Response::IdentitySearchJob.build(http_response, connection, location)
+        )
+        allow(Cognito::Client::Command::RetrieveIdentitySearchJob).to receive(:call)
+        expect do
+          response.get
+        end.to raise_error KeyError, /Content-Location/
+      end
+    end
   end
 
   it_behaves_like 'a command with an unexpected response code' do

--- a/spec/unit/cognito/client/response/identity_search_job_spec.rb
+++ b/spec/unit/cognito/client/response/identity_search_job_spec.rb
@@ -3,11 +3,13 @@
 RSpec.describe Cognito::Client::Response::IdentitySearchJob do
   include_context 'response wrapper'
 
+  subject(:response) { described_class.build(http_response, connection, location) }
   let(:body)        { ''  }
+  let(:location)    { 'some_uri' }
   let(:status_code) { 202 }
 
   let(:headers) do
-    { 'Content-Location' => 'some_uri' }
+    { 'Content-Location' => location }
   end
 
   its(:processing?) { is_expected.to be(true) }

--- a/spec/unit/cognito/client_spec.rb
+++ b/spec/unit/cognito/client_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Cognito::Client do
       allow(connection).to receive(:run).and_return(created_response)
 
       expect(client.create_identity_search(params)).to eql(
-        Cognito::Client::Response::IdentitySearchJob.build(created_response, connection)
+        Cognito::Client::Response::IdentitySearchJob.build(created_response, connection, endpoint)
       )
     end
 


### PR DESCRIPTION
## Summary:

`Response::IdentitySearchJob#get` builds a new
`Command::RetrieveIdentitySearchJob` to check on the status of an async search
using the `Content-Location` header. The `Content-Location` header is not present when the
`Response::IdentitySearchJob` is the result of a previous
`Command::RetrieveIdentitySearchJob`.

## Bug details:

The sequence of events is documented by Cognito on this page:
https://cognitohq.com/docs/verifying-with-phone

When the `Command::CreateIdentitySearch` receives a 202 response, it will build
an initial `Response::IdentitySearchJob` and the underlying response contains
the `Content-Location` header.

`Response::IdentitySearchJob#get` then builds an initial
`Command::RetrieveIdentitySearchJob` using the `Content-Location` header.

If this initial command then recieves a 200 response, the command will build a second `Response::IdentitySearchJob` and the underlying response no longer contains the
`Content-Location` header.

Attempting to use the second `Response::IdentitySearchJob#get` method to build
a second `Command::RetrieveIdentitySearchJob` to recheck on the status of the
async search job will fail.

## Fix:

Build `Response::IdentitySearchJob` with endpoint
    
`Response::IdentitySearchJob` accepts an endpoint parameter for `.build`. On
intial use from `Command::CreateIdentitySearch`, endpoint is passed from the
`Content-Location` header. On subsequent use from
`Command::RetrieveIdentitySearchJob`, endpoint is copied from the current job.