### PR TITLE
CVE-2021-32740 - Upgrade addressable to ~>2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@
 /spec/reports/
 /tmp/
 .DS_Store
-
+/.ruby-version
 *.gem

--- a/Gemfile
+++ b/Gemfile
@@ -5,32 +5,9 @@ source 'https://rubygems.org'
 gemspec
 
 group(:tools) do
-  # mutation testing tool for ruby
-  gem 'mutant',       '~> 0.8.10'
-
-  # Rspec integration for mutant
-  gem 'mutant-rspec', '~> 0.8.8'
-
-  # A metagem wrapping development tools:
-  #   procto,
-  #   adamantium,
-  #   anima,
-  #   concord,
-  #   rspec, rspec-core, rspec-its
-  #   rake,
-  #   yard,
-  #   flog,
-  #   flay,
-  #   reek,
-  #   rubocop,
-  #   simplecov,
-  #   yardstick,
-  #   mutant, mutant-rspec
-  gem 'devtools', '~> 0.1.8'
-
+  gem 'mutant'
+  gem 'mutant-rspec'
+  gem 'devtools'
   # Rubocop extensions which reflect BlockScore's style guide
   gem 'rubocop-devtools', git: 'https://github.com/backus/rubocop-devtools.git'
-
-  # Enforce style and convention for rspec
-  gem 'rubocop-rspec', git: 'https://github.com/nevir/rubocop-rspec.git'
 end

--- a/cognito.gemspec
+++ b/cognito.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '~>2.2'
   spec.add_development_dependency 'pry', '~> 0.10'
 
   spec.add_dependency 'abstract_type', '~> 0.0.7'
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ice_nine', '~> 0.11.2'
 
   spec.add_runtime_dependency 'http', '~> 2.0', '>= 2.0.3'
-  spec.add_runtime_dependency 'addressable', '~> 2.4', '= 2.4.0'
+  spec.add_runtime_dependency 'addressable', '~> 2.8'
 end


### PR DESCRIPTION
[CVE-2021-32740](https://nvd.nist.gov/vuln/detail/CVE-2021-32740)
In addition, I cleaned up some of the other gem versions to fix other dependency issues. 
